### PR TITLE
Fix help dialog formatting with Terminal.Gui 0.90.3

### DIFF
--- a/Sizable/Gui.fs
+++ b/Sizable/Gui.fs
@@ -5,6 +5,7 @@ open NStack
 
 open Sizable.FileSystem
 open Sizable.Config
+open System
 open System.IO.Abstractions
 open System.Collections.Concurrent
 open FSharp.Collections.ParallelSeq
@@ -139,7 +140,11 @@ type Tui(state: StateManager) =
                     Application.Top.Running <- false
                     true
                 elif k.KeyValue = int '?' then
-                    MessageBox.Query(72, 14, ustr "Help", ustr helpMsg, ustr "OK") |> ignore
+                    let okBtn = new Button(ustr "OK", true)
+                    okBtn.add_Clicked(Action(Application.RequestStop))
+                    let helpDialog = new Dialog(ustr "help", 72, 14, okBtn)
+                    helpDialog.Add(new Label (Rect(2, 1, 72, 10), ustr helpMsg, TextAlignment = TextAlignment.Left))
+                    Application.Run helpDialog
                     true
                 else
                     base.ProcessKey k }


### PR DESCRIPTION
Since for some reason in Termina.Gui 0.9 MessageBox text is centered... https://github.com/migueldeicaza/gui.cs/blob/66d9f4242687361357214ab62ff6275a81f83d9c/Terminal.Gui/Windows/MessageBox.cs#L129